### PR TITLE
Fix list to show today and tomorrow reservations only and the related showallpredicate.

### DIFF
--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -12,7 +12,7 @@ import seedu.address.model.reservation.Reservation;
  */
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
-    Predicate<Reservation> PREDICATE_SHOW_ALL_RESERVATIONS = unused -> true;
+    Predicate<Reservation> PREDICATE_SHOW_ALL_RESERVATIONS = ReservationsFilter.filterForTodayOrTomorrowPredicate();
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -85,9 +85,12 @@ public interface Model {
     void filterReservationsForToday(Predicate<Reservation> predicate);
 
     void filterReservationsForTomorrow(Predicate<Reservation> predicate);
+
+
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredReservationList(Predicate<Reservation> predicate);
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -123,6 +123,7 @@ public class ModelManager implements Model {
         return filteredReservations;
     }
 
+    @Override
     public ObservableList<Reservation> getOverallReservationList() {
         updateFilteredReservationList(PREDICATE_SHOW_ALL_RESERVATIONS);
         return filteredReservations;
@@ -143,9 +144,11 @@ public class ModelManager implements Model {
     @Override
     public void filterReservationsForTomorrow(Predicate<Reservation> predicate) {
         requireNonNull(predicate);
-        Predicate<Reservation> todayPredicate = ReservationsFilter.filterForTomorrow(filteredReservations);
-        filteredReservations.setPredicate(todayPredicate);
+        Predicate<Reservation> tomorrowPredicate = ReservationsFilter.filterForTomorrow(filteredReservations);
+        filteredReservations.setPredicate(tomorrowPredicate);
     }
+
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {

--- a/src/main/java/seedu/address/model/ReservationsFilter.java
+++ b/src/main/java/seedu/address/model/ReservationsFilter.java
@@ -41,4 +41,26 @@ public class ReservationsFilter {
         Predicate<Reservation> tomorrowPredicate = reservation -> reservation.getDate().value.equals(tomorrowDate);
         return tomorrowPredicate;
     }
+
+    /**
+     * Returns a predicate that filters reservations scheduled for tomorrow or today.
+     *
+     *
+     * @return Predicate for tomorrow or today reservations
+     */
+    public static Predicate<Reservation> filterForTodayOrTomorrowPredicate() {
+        LocalDate today = LocalDate.now();
+        LocalDate tomorrow = today.plusDays(1);
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        String todayDate = today.format(formatter);
+        String tomorrowDate = tomorrow.format(formatter);
+
+        // Predicate to check if the reservation is either today or tomorrow
+        Predicate<Reservation> todayOrTomorrowPredicate = reservation ->
+                reservation.getDate().value.equals(todayDate) || reservation.getDate().value.equals(tomorrowDate);
+
+        return todayOrTomorrowPredicate;
+    }
+
 }


### PR DESCRIPTION
Fixes #98  
### Things to Note 
* Previously, the `list` command will show also previous records which is of stale date. But in our use case (for this milestone), we will want it to show only today or tomorrow reservations points.
* `SHOWALLPREDICATE` under `Model.java` is changed. 
* For more rigorous testing, try to manipulate the test data in `addressbook.json`to become stale data. If the program is working correctly, you should not see any single stale data being displayed to the UI regardless of what command you enter.