### PR TITLE
Fix `RemarkCommand`

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,7 +15,8 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
 
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX = "The Reservation index provided is invalid";
+    public static final String MESSAGE_INVALID_RESERVATION_DISPLAYED_INDEX =
+            "The Reservation index provided is invalid";
     public static final String MESSAGE_RESERVATIONS_LISTED_OVERVIEW = "%1$d reservations listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -31,7 +31,8 @@ public class FindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredReservationList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_RESERVATIONS_LISTED_OVERVIEW, model.getFilteredReservationList().size()));
+                String.format(Messages.MESSAGE_RESERVATIONS_LISTED_OVERVIEW,
+                        model.getFilteredReservationList().size()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -20,9 +20,9 @@ public class RemarkCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the remark of the person identified "
             + "by the index number used in the last person listing. "
             + "Existing remark will be overwritten by the input.\n"
-            + "Parameters: INDEX (must be a positive integer) "
+            + "Parameters: Reservation ID (date of reservation in DDMMYYYY + last 4 digits of phone number) "
             + PREFIX_REMARK + "[REMARK]\n"
-            + "Example: " + COMMAND_WORD + " 1 "
+            + "Example: " + COMMAND_WORD + " 01012025 "
             + PREFIX_REMARK + "Likes to swim.";
 
     public static final String MESSAGE_ADD_REMARK_SUCCESS = "Added remark to Person: %1$s";

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -14,6 +14,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_PAX = new Prefix("pax/");
     public static final Prefix PREFIX_TABLE = new Prefix("table/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-    public static final Prefix PREFIX_REMARK = new Prefix("/r");
+    public static final Prefix PREFIX_REMARK = new Prefix("r/");
     public static final Prefix PREFIX_ID = new Prefix("id/");
 }


### PR DESCRIPTION
Fixed remark command:
* Display correct message to show correct information (using Identification ID instead of index)
* Changed `PREFIX_REMARK` from '/r' to 'r/'