### PR TITLE
Fix `Add` command remark detection

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DURATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PAX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TABLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
@@ -32,7 +33,8 @@ public class AddCommand extends Command {
             + PREFIX_DURATION + "DURATION "
             + PREFIX_PAX + "PAX "
             + PREFIX_TABLE + "TABLE "
-            + "[" + PREFIX_TAG + "TAG]..."
+            + "[" + PREFIX_TAG + "TAG]... "
+            + "[" + PREFIX_REMARK + "REMARK]. "
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TABLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -62,7 +63,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Duration duration = ParserUtil.parseDuration(argMultimap.getValue(PREFIX_DURATION).get());
         Pax pax = ParserUtil.parsePax(argMultimap.getValue(PREFIX_PAX).get());
         Table table = ParserUtil.parseTable(argMultimap.getValue(PREFIX_TABLE).get());
-        Remark remark = new Remark("");
+        Remark remark = ParserUtil.parseRemark(getValueOrEmpty(argMultimap, PREFIX_REMARK));
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         // Make use of current date ddMMyyyy and last 4 digits of phone and current reservation count
         // to form a unique key id
@@ -81,4 +82,16 @@ public class AddCommandParser implements Parser<AddCommand> {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
+    /**
+     * Returns the value associated with the specified {@code prefix} in the given {@code argumentMultimap},
+     * or an empty string if no value is present.
+     *
+     * @param argumentMultimap The map containing prefix-value mappings.
+     * @param prefix The prefix whose associated value is to be returned.
+     * @return The last value associated with the prefix, or an empty string if not present.
+     */
+    private String getValueOrEmpty(ArgumentMultimap argumentMultimap, Prefix prefix) {
+        Optional<String> optionalValue = argumentMultimap.getValue(prefix);
+        return optionalValue.orElse("");
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DURATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PAX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TABLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
@@ -43,7 +44,7 @@ public class AddCommandParser implements Parser<AddCommand> {
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_DATE, PREFIX_TIME, PREFIX_DURATION,
-                        PREFIX_PAX, PREFIX_TABLE, PREFIX_TAG);
+                        PREFIX_PAX, PREFIX_TABLE, PREFIX_TAG, PREFIX_REMARK);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_DATE, PREFIX_TIME, PREFIX_DURATION,
                 PREFIX_PAX, PREFIX_TABLE)
@@ -53,8 +54,7 @@ public class AddCommandParser implements Parser<AddCommand> {
 
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_DATE, PREFIX_TIME, PREFIX_DURATION,
-                PREFIX_PAX, PREFIX_TABLE);
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE);
+                PREFIX_PAX, PREFIX_TABLE, PREFIX_REMARK);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         StartDate date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -12,6 +12,7 @@ import seedu.address.model.reservation.Identification;
 import seedu.address.model.reservation.Name;
 import seedu.address.model.reservation.Pax;
 import seedu.address.model.reservation.Phone;
+import seedu.address.model.reservation.Remark;
 import seedu.address.model.reservation.StartDate;
 import seedu.address.model.reservation.StartTime;
 import seedu.address.model.reservation.Table;
@@ -155,6 +156,17 @@ public class ParserUtil {
             throw new ParseException(Table.MESSAGE_CONSTRAINTS);
         }
         return new Table(trimmedTable);
+    }
+
+    /**
+     * Parses a {@code String Remark} into an {@code Remark}.
+     * Leading and trailing whitespaces will be trimmed.
+     */
+    public static Remark parseRemark(String remark) {
+        requireNonNull(remark);
+        String trimmedRemark = remark.trim();
+        //No invalid remark
+        return new Remark(trimmedRemark);
     }
 
     /**


### PR DESCRIPTION
* Fixed `add` command to be able to detect and update remark field of new reservation
* Removed editing remark to avoid overlap of functionality of `edit` and `remark`

Fix #173 
Fix #184 
