### PR TITLE
Fix findt bug regarding overnight reservations

### DIFF
--- a/src/main/java/seedu/address/model/reservation/TimeMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/reservation/TimeMatchesPredicate.java
@@ -23,6 +23,11 @@ public class TimeMatchesPredicate implements Predicate<Reservation> {
         int durationMinutes = reservation.getDuration().toMinutes();
         LocalTime endTime = startTime.plusMinutes(durationMinutes);
 
+        // If reservation spans overnight, clip endTime to 11:59
+        if (endTime.isBefore(startTime)) {
+            endTime = LocalTime.of(23, 59);
+        }
+
         // The reservation is ongoing at searchTime if startTime <= searchTime < endTime.
         return !startTime.isAfter(searchTime) && searchTime.isBefore(endTime);
 

--- a/src/main/java/seedu/address/model/reservation/TimeMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/reservation/TimeMatchesPredicate.java
@@ -25,7 +25,7 @@ public class TimeMatchesPredicate implements Predicate<Reservation> {
 
         // If reservation spans overnight, clip endTime to 11:59
         if (endTime.isBefore(startTime)) {
-            endTime = LocalTime.of(23, 59);
+            endTime = LocalTime.of(23, 59, 59);
         }
 
         // The reservation is ongoing at searchTime if startTime <= searchTime < endTime.


### PR DESCRIPTION
Fixes #338 

Fixed bug such that `findt` will display ongoing reservations even if it goes to the next day. E.g. for reservation with start time of 1800 and duration of 12h, `findt 1800` or `findt 2300` will display this reservation.

Currently, `findt` displays all ongoing reservations today only. So if reservation starts at 2300 and has duration of 3h, `findt 0100` will not display this reservation since its the next day. But not sure if this is the best functionality since it makes more sense for restaurant to want to check ongoing reservations at certain times for both today and tomorrow to see if can slot in. 

Do yall think should change this command to be like `findt DATE TIME` so it can check ongoing reservations tomorrow also? I think it would definitely improve the feature but I'm just scared it'll cause more bugs.

Also please help me to test this command out, using .5 durations, overnight durations etc 🙏 